### PR TITLE
put the upgrade sql scripts into the python pod

### DIFF
--- a/docker-build/modules/python/Dockerfile
+++ b/docker-build/modules/python/Dockerfile
@@ -11,12 +11,14 @@ COPY eggroll.tar.gz .
 COPY examples.tar.gz .
 COPY conf.tar.gz .
 COPY fate.env .
+COPY deploy.tar.gz .
 
 RUN tar -xzf fate.tar.gz; \
     tar -xzf fateflow.tar.gz; \
     tar -xzf eggroll.tar.gz; \
     tar -xzf examples.tar.gz; \
-    tar -xzf conf.tar.gz;
+    tar -xzf conf.tar.gz; \
+    tar -xzf deploy.tar.gz;
 
 FROM ${PREFIX}/base-image:${BASE_TAG}
 
@@ -28,6 +30,7 @@ COPY  --from=builder /data/projects/fate/eggroll /data/projects/fate/eggroll
 COPY  --from=builder /data/projects/fate/examples /data/projects/fate/examples
 COPY  --from=builder /data/projects/fate/conf /data/projects/fate/conf
 COPY  --from=builder /data/projects/fate/fate.env /data/projects/fate/
+COPY  --from=builder /data/projects/fate/deploy/upgrade/sql /data/projects/fate/deploy/upgrade/sql
 
 RUN mkdir -p ./fml_agent/data; 
 


### PR DESCRIPTION
Signed-off-by: Chen Jing <jingch@vmware.com>

## Description

The python pod should have the upgrade scripts.
When after upgrade, the python pod will:
1. check the readiness of mysql.
2. run some of the scripts against mysql.
3. launch the fateflow service.

## Test

After this change, I have rebuild the containers and verified that the sql scripts are in the expected position of the pod directory:

```
11:05:31 root@control-plane k8s-deploy ±|issue-556 ✗|→ kubectl -n fate-9999 exec -it python-0 -c python bash
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
(app-root) bash-4.2# ls
conf  conf-tmp	deploy	eggroll  examples  fate  fate.env  fateflow  fml_agent
(app-root) bash-4.2# cd deploy/
(app-root) bash-4.2# ls
upgrade
(app-root) bash-4.2# cd upgrade/
(app-root) bash-4.2# ls
sql
(app-root) bash-4.2# cd sql/
(app-root) bash-4.2# ls
1.6.0-1.6.1.sql  1.6.1-1.7.0.sql  1.7.0-1.7.1.sql  1.7.1-1.7.2.sql  1.7.2-1.8.0.sql
```