### PR TITLE
Add the docker file and build steps for the FATE upgrade manager

### DIFF
--- a/docker-build/build.sh
+++ b/docker-build/build.sh
@@ -111,7 +111,7 @@ buildAlgorithmNN(){
 
 buildFateUpgradeManager(){
         echo "START BUILDING fate-upgrade-manager"
-        cp ${WORKING_DIR}/fate-upgrade-manager/upgrade-mysql.py ${PACKAGE_DIR_CACHE}
+        cp ${WORKING_DIR}/modules/fate-upgrade-manager/upgrade-mysql.py ${PACKAGE_DIR_CACHE}
         docker build --build-arg PREFIX=${PREFIX} --build-arg BASE_TAG=${BASE_TAG} ${docker_options} -t ${PREFIX}/fate-upgrade-manager:${TAG} -f ${WORKING_DIR}/modules/fate-upgrade-manager/Dockerfile ${PACKAGE_DIR_CACHE}
         echo "FINISH BUILDING fate-upgrade-manager"
 }

--- a/docker-build/build.sh
+++ b/docker-build/build.sh
@@ -136,6 +136,7 @@ buildModule(){
         buildComponentSparkModule
         buildOptionalModule
         buildAlgorithmNN
+        buildFateUpgradeManager
 }
 
 pushImage() {

--- a/docker-build/build.sh
+++ b/docker-build/build.sh
@@ -109,6 +109,14 @@ buildAlgorithmNN(){
         echo ""
 }
 
+buildFateUpgradeManager(){
+        echo "START BUILDING fate-upgrade-manager"
+        docker build --build-arg PREFIX=${PREFIX} --build-arg BASE_TAG=${BASE_TAG} ${docker_options} -t
+        ${PREFIX}/fate-upgrade-manager:${TAG} -f ${WORKING_DIR}/modules/fate-upgrade-manager/Dockerfile
+        ${PACKAGE_DIR_CACHE}
+        echo "FINISH BUILDING fate-upgrade-manager"
+}
+
 buildOptionalModule(){
 
         echo "START BUILDING Optional Module IMAGE"

--- a/docker-build/build.sh
+++ b/docker-build/build.sh
@@ -111,9 +111,8 @@ buildAlgorithmNN(){
 
 buildFateUpgradeManager(){
         echo "START BUILDING fate-upgrade-manager"
-        docker build --build-arg PREFIX=${PREFIX} --build-arg BASE_TAG=${BASE_TAG} ${docker_options} -t
-        ${PREFIX}/fate-upgrade-manager:${TAG} -f ${WORKING_DIR}/modules/fate-upgrade-manager/Dockerfile
-        ${PACKAGE_DIR_CACHE}
+        cp ${WORKING_DIR}/fate-upgrade-manager/upgrade-mysql.py ${PACKAGE_DIR_CACHE}
+        docker build --build-arg PREFIX=${PREFIX} --build-arg BASE_TAG=${BASE_TAG} ${docker_options} -t ${PREFIX}/fate-upgrade-manager:${TAG} -f ${WORKING_DIR}/modules/fate-upgrade-manager/Dockerfile ${PACKAGE_DIR_CACHE}
         echo "FINISH BUILDING fate-upgrade-manager"
 }
 

--- a/docker-build/modules/fate-upgrade-manager/Dockerfile
+++ b/docker-build/modules/fate-upgrade-manager/Dockerfile
@@ -1,0 +1,16 @@
+ARG PREFIX=prefix
+ARG BASE_TAG=tag
+
+FROM ${PREFIX}/base-image:${BASE_TAG} as builder
+
+WORKDIR /data/projects/fate/
+COPY deploy.tar.gz .
+
+RUN tar -xzf deploy.tar.gz;
+
+FROM centos/python-36-centos7
+
+COPY  --from=builder /data/projects/fate/deploy/upgrade/sql ./sql
+COPY upgrade-mysql.py .
+
+RUN pip install mysql-connector-python

--- a/docker-build/modules/fate-upgrade-manager/Dockerfile
+++ b/docker-build/modules/fate-upgrade-manager/Dockerfile
@@ -10,7 +10,9 @@ RUN tar -xzf deploy.tar.gz;
 
 FROM centos/python-36-centos7
 
+WORKDIR /
 COPY  --from=builder /data/projects/fate/deploy/upgrade/sql ./sql
 COPY upgrade-mysql.py .
 
-RUN pip install mysql-connector-python
+RUN pip install --upgrade pip && \
+    pip install mysql-connector-python

--- a/docker-build/modules/fate-upgrade-manager/upgrade-mysql.py
+++ b/docker-build/modules/fate-upgrade-manager/upgrade-mysql.py
@@ -1,0 +1,64 @@
+import mysql.connector
+import sys
+import os
+
+
+def get_script_list(start_ver, target_ver):
+    sql_script_names = os.listdir("sql")
+    sql_script_names.sort()
+    res = []
+    start_index = -1
+    end_index = -1
+    for i in range(len(sql_script_names)):
+        if sql_script_names[i].startswith(start_ver):
+            start_index = i
+        if sql_script_names[i].replace(".sql", "").endswith(target_ver):
+            end_index = i
+    if start_index == -1 or end_index == -1 or start_index > end_index:
+        return res
+    res = sql_script_names[start_index:end_index+1]
+    print("will run scripts:")
+    print(res)
+    return res
+
+
+def preprocess_script(script):
+    queries = []
+    query = ''
+    delimiter = ';'
+    with open("sql/%s" % script, "r") as sql_file:
+        for line in sql_file.readlines():
+            line = line.strip()
+            if line.startswith('DELIMITER'):
+                delimiter = line[10:]
+            else:
+                query += line+'\n'
+                if line.endswith(delimiter):
+                    # Get rid of the delimiter, remove any blank lines and add this query to our list
+                    queries.append(query.strip().strip(delimiter))
+                    query = ''
+    return queries
+
+
+def run_script(script, cursor):
+    queries = preprocess_script(script)
+    for query in queries:
+        if not query.strip():
+            continue
+        print("execute query %s" % query)
+        cursor.execute(query)
+
+
+if __name__ == '__main__':
+    _, user, password, start_ver, end_ver = sys.argv
+    scripts_to_run = get_script_list(start_ver, end_ver)
+    mydb = mysql.connector.connect(
+        host="mysql",
+        user=user,
+        password=password,
+        database="eggroll_meta"
+    )
+    cursor = mydb.cursor()
+    for script in scripts_to_run:
+        run_script(script, cursor)
+    cursor.close()

--- a/docker-build/modules/python/Dockerfile
+++ b/docker-build/modules/python/Dockerfile
@@ -11,14 +11,12 @@ COPY eggroll.tar.gz .
 COPY examples.tar.gz .
 COPY conf.tar.gz .
 COPY fate.env .
-COPY deploy.tar.gz .
 
 RUN tar -xzf fate.tar.gz; \
     tar -xzf fateflow.tar.gz; \
     tar -xzf eggroll.tar.gz; \
     tar -xzf examples.tar.gz; \
-    tar -xzf conf.tar.gz; \
-    tar -xzf deploy.tar.gz;
+    tar -xzf conf.tar.gz;
 
 FROM ${PREFIX}/base-image:${BASE_TAG}
 
@@ -30,7 +28,6 @@ COPY  --from=builder /data/projects/fate/eggroll /data/projects/fate/eggroll
 COPY  --from=builder /data/projects/fate/examples /data/projects/fate/examples
 COPY  --from=builder /data/projects/fate/conf /data/projects/fate/conf
 COPY  --from=builder /data/projects/fate/fate.env /data/projects/fate/
-COPY  --from=builder /data/projects/fate/deploy/upgrade/sql /data/projects/fate/deploy/upgrade/sql
 
 RUN mkdir -p ./fml_agent/data; 
 


### PR DESCRIPTION
## Description

fate-upgrade-manager's duty is:
1. Accept 4 arguments, which is the mysql's username, password, the starting upgrade version and the target upgrade version.
2. It connects the mysql container which is used by fateflow.
3. Based on the start version and target version, it calculates the scripts it need to run in sequence. Of course, we have already build the scripts into the image.
4. It executes the sql commands in the scripts.

KubeFATE will launch a K8s job for fate-upgrade-manager, when it detects that the version has been changed. That part of helm chart has been merged in the Kubefate repo. See [here](https://github.com/FederatedAI/KubeFATE/pull/688).

After the scripts are executed successfully. Kubefate will upgrade the pods of the FATE compnents. This part of work is the next step we are going to do.

Also, we find that there is no need to build the sql scripts into the python image, so basicially a part of this change is to revert the previous change. The sql scripts will be built into the fate-upgrade-manager image.


## Test

1. Verified that the build script can work properly after change,  we can build the fate-upgrade-manager image.
2. The image reuse the the python image's base image, so the delta size is very small. 
3. The python script has been test comprehensively, including every combination of the arguments, it behaves within expectation.
4. Have verified that each line of the SQL scripts can be run successfully.
5. More test steps can be seen [here](https://github.com/FederatedAI/KubeFATE/pull/688)

We will do e2e upgrade test when we do the next task.



