### PR TITLE
shutdown fateflow before modify the mysql database

### DIFF
--- a/docker-build/build.sh
+++ b/docker-build/build.sh
@@ -111,7 +111,7 @@ buildAlgorithmNN(){
 
 buildFateUpgradeManager(){
         echo "START BUILDING fate-upgrade-manager"
-        cp ${WORKING_DIR}/modules/fate-upgrade-manager/upgrade-mysql.py ${PACKAGE_DIR_CACHE}
+        cp ${WORKING_DIR}/modules/fate-upgrade-manager/*.py ${PACKAGE_DIR_CACHE}
         docker build --build-arg PREFIX=${PREFIX} --build-arg BASE_TAG=${BASE_TAG} ${docker_options} -t ${PREFIX}/fate-upgrade-manager:${TAG} -f ${WORKING_DIR}/modules/fate-upgrade-manager/Dockerfile ${PACKAGE_DIR_CACHE}
         echo "FINISH BUILDING fate-upgrade-manager"
 }

--- a/docker-build/modules/fate-upgrade-manager/Dockerfile
+++ b/docker-build/modules/fate-upgrade-manager/Dockerfile
@@ -13,6 +13,8 @@ FROM centos/python-36-centos7
 WORKDIR /
 COPY  --from=builder /data/projects/fate/deploy/upgrade/sql ./sql
 COPY upgrade-mysql.py .
+COPY shutdown-flow.py .
 
 RUN pip install --upgrade pip && \
-    pip install mysql-connector-python
+    pip install mysql-connector-python && \
+    pip install kubernetes

--- a/docker-build/modules/fate-upgrade-manager/shutdown-flow.py
+++ b/docker-build/modules/fate-upgrade-manager/shutdown-flow.py
@@ -1,0 +1,56 @@
+import sys
+import time
+from kubernetes import client, config
+APP_NAME = "python"
+def shutdown_flow(namespace, api, app):
+    if type(app) == client.V1Deployment:
+        update_deployment(namespace, api, app)
+    else:
+        update_sts(namespace, api, app)
+    for _ in range(60):
+        if type(app) == client.V1Deployment:
+            app = api.read_namespaced_deployment_status(APP_NAME, namespace)
+        else:
+            app = api.read_namespaced_stateful_set_status(APP_NAME, namespace)
+        print("the ready replicas number is %s" % app.status.ready_replicas)
+        if not app.status.ready_replicas:
+            # The default grace time period is 30 seconds
+            print("sleep for another 30 seconds, make sure the flow's pod is down")
+            time.sleep(30)
+            return 0
+        else:
+            print("wait for 10 seconds and will recheck")
+            time.sleep(10)
+    print("cannot shutdown the flow's pod")
+    return 1
+def get_flow_app(namespace, api):
+    deployments = api.list_namespaced_deployment(namespace)
+    stss = api.list_namespaced_stateful_set(namespace)
+    for deployment in deployments.items:
+        if deployment.metadata.name == APP_NAME:
+            return deployment
+    for sts in stss.items:
+        if sts.metadata.name == APP_NAME:
+            return sts
+    return None
+def update_deployment(namespace, api, app):
+    # Update container image
+    app.spec.replicas = 0
+    api.patch_namespaced_deployment(
+        name=APP_NAME, namespace=namespace, body=app
+    )
+def update_sts(namespace, api, app):
+    app.spec.replicas = 0
+    api.patch_namespaced_stateful_set(
+        name=APP_NAME, namespace=namespace, body=app
+    )
+if __name__ == '__main__':
+    _, namespace = sys.argv
+    config.load_incluster_config()
+    apps_v1 = client.AppsV1Api()
+    app = get_flow_app(namespace, apps_v1)
+    if not app:
+        print("cannot find any deployment/sts whose name is 'python'")
+        exit()
+    return_code = shutdown_flow(namespace, apps_v1, app)
+    exit(return_code)


### PR DESCRIPTION
Signed-off-by: Chen Jing <jingch@vmware.com>

This change added another python script which helps to shut down the pod of fateflow, before we change the mysql schema.


This change has been well tested. The test report can be seen [here](https://github.com/FederatedAI/KubeFATE/pull/690/files)

In this repo, has also verified after change, the build script can be executed successfully.