### PR TITLE
Change python version

### DIFF
--- a/docker-build/base/basic/Dockerfile
+++ b/docker-build/base/basic/Dockerfile
@@ -3,9 +3,8 @@ FROM centos:centos7
 ARG version
 
 USER root
-
+ENV VIRTUAL_ENV ""
 WORKDIR /data/projects/python/
-
 COPY requirements.txt /data/projects/python/
 
 RUN set -eux && \

--- a/docker-build/base/basic/Dockerfile
+++ b/docker-build/base/basic/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos/python-38-centos7
+FROM centos/centos7
 
 ARG version
 
@@ -15,6 +15,22 @@ RUN set -eux && \
     libmpcdevel libaio numactl autoconf automake libtool libffi-devel  \
     snappy snappy-devel zlib zlib-devel bzip2 bzip2-devel lz4-devel libasan lsof sysstat telnet psmisc && \
     yum clean all
+
+RUN curl -o Python-3.8.13.tar.xz https://www.python.org/ftp/python/3.8.13/Python-3.8.13.tar.xz && \
+    tar -xvf Python-3.8.13.tar.xz && \
+    cd Python-3.8.13 && \
+    ./configure --prefix=/opt/python3 && \
+    make altinstall && \
+    ln -s /opt/python3/bin/python3.8 /usr/bin/python3.8 && \
+    ln -s /usr/bin/python3.8 /usr/bin/python3 && \
+    rm -f /usr/bin/python && \
+    ln -s /usr/bin/python3 /usr/bin/python && \
+    ln -s /opt/python3/bin/pip3.8 /usr/bin/pip3.8 && \
+    ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \
+    ln -s /usr/bin/pip3 /usr/bin/pip && \
+    cd .. && \
+    rm Python-3.8.13.tar.xz && \
+    rm -rf Python-3.8.13
 
 RUN pip install --upgrade pip && \
     sed -i '/tensorflow.*/d' /data/projects/python/requirements.txt && \

--- a/docker-build/base/basic/Dockerfile
+++ b/docker-build/base/basic/Dockerfile
@@ -21,10 +21,9 @@ RUN curl -o Python-3.8.13.tar.xz https://www.python.org/ftp/python/3.8.13/Python
     cd Python-3.8.13 && \
     ./configure --prefix=/opt/python3 && \
     make altinstall && \
-    ln -s /opt/python3/bin/python3.8 /usr/bin/python3.8 && \
-    ln -s /usr/bin/python3.8 /usr/bin/python3 && \
-    rm -f /usr/bin/python && \
-    ln -s /usr/bin/python3 /usr/bin/python && \
+    ln -s /opt/python3/bin/python3.8 /usr/local/bin/python3.8 && \
+    ln -s /usr/local/bin/python3.8 /usr/local/bin/python3 && \
+    ln -s /usr/local/bin/python3 /usr/local/bin/python && \
     ln -s /opt/python3/bin/pip3.8 /usr/bin/pip3.8 && \
     ln -s /usr/bin/pip3.8 /usr/bin/pip3 && \
     ln -s /usr/bin/pip3 /usr/bin/pip && \

--- a/docker-build/base/basic/Dockerfile
+++ b/docker-build/base/basic/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos/centos7
+FROM centos:centos7
 
 ARG version
 


### PR DESCRIPTION
The centos/python-38-centos7 has a Python version which is 3.8.6

In this change i change the docker file, to change the Python version to 3.8.13

I have tested every archetecture, eggroll/spark + rabbitmq+pulsar.

It turns out that my change is good, all the test cases passed.