### PR TITLE
Prepare to release 1.1.1 to replace 1.1.0 because it fix a bug of fate upgrade manager

### DIFF
--- a/docker-build/modules/fate-upgrade-manager/Dockerfile
+++ b/docker-build/modules/fate-upgrade-manager/Dockerfile
@@ -8,7 +8,7 @@ COPY deploy.tar.gz .
 
 RUN tar -xzf deploy.tar.gz;
 
-FROM centos/python-36-centos7
+FROM python:3.8
 
 WORKDIR /
 COPY  --from=builder /data/projects/fate/deploy/upgrade/sql ./sql


### PR DESCRIPTION
This is a patch release of 1.1.0

If we use 1.1.0 to build fate upgrade manager v1.10.0, then it could will fail when we do a jump upgrade between certain versions, such as from 1.8.0 directly to 1.10.0.
Consequtive upgrade has no issue with 1.1.0.

After fix, we support jump upgrade, I would like to release this patch and mention that we support building FATE 1.10.x images with Fate-Builder v1.1.1.

