### PR TITLE
Ubuntu添加了"libtinfo5"依赖包

### DIFF
--- a/native-build/templates/fate_cluster_install/base-install/install_os_dependencies.sh
+++ b/native-build/templates/fate_cluster_install/base-install/install_os_dependencies.sh
@@ -31,7 +31,7 @@ case "${system}" in
             ;;
     "Ubuntu")
             echo "Ubuntu System"
-            $command apt-get install -y gcc g++ make  openssl supervisor libgmp-dev  libmpfr-dev libmpc-dev libaio1 libaio-dev numactl autoconf automake libtool libffi-dev libssl1.0.0 libssl-dev  liblz4-1 liblz4-dev liblz4-1-dbg liblz4-tool  zlib1g zlib1g-dbg zlib1g-dev
+            $command apt-get install -y gcc g++ make  openssl supervisor libgmp-dev  libmpfr-dev libmpc-dev libaio1 libaio-dev numactl autoconf automake libtool libffi-dev libssl1.0.0 libssl-dev  liblz4-1 liblz4-dev liblz4-1-dbg liblz4-tool  zlib1g zlib1g-dbg zlib1g-dev libtinfo5
             cd /usr/lib/x86_64-linux-gnu
             if [ ! -f "libssl.so.10" ];then
                  $command ln -s libssl.so.1.0.0 libssl.so.10


### PR DESCRIPTION
![微信截图_20240905102227](https://github.com/user-attachments/assets/726d78c0-7227-4b79-9614-6d6622847037)
![微信截图_20240905104443](https://github.com/user-attachments/assets/151123d7-bd34-45c6-8751-3bfd2ee64e9f)
Ubuntu缺少libtinfo5的包导致无法通过命令行进入数据库进行初始化。